### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/bobbrodie/propublica-nonprofit-explorer-sdk/security/code-scanning/5](https://github.com/bobbrodie/propublica-nonprofit-explorer-sdk/security/code-scanning/5)

To remediate this issue, add a `permissions:` block either at the workflow root (recommended for these read-only jobs), or individually within each job. Given all jobs are non-modifying (no `actions/checkout` with push, no issue/comment management), the safest minimal configuration is `contents: read` at the workflow root. This limits the GITHUB_TOKEN used in all jobs to only the read permission for repository contents, following the principle of least privilege and meeting the CodeQL recommendation. Edit `.github/workflows/ci.yml` by inserting the block directly under the `name: CI` line (or before `jobs:`), being careful not to affect existing job setups.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
